### PR TITLE
feat: add survey editing and food entry deletion

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -20,8 +20,12 @@
     const surveyModal = document.getElementById('survey-modal-backdrop');
     const surveySubmitBtn = document.getElementById('survey-submit');
     const goalContent = document.getElementById('goal-content');
+    const editProfileBtn = document.getElementById('edit-profile-btn');
+    const surveyHelp = document.getElementById('survey-help');
+    const surveyModalTitle = document.getElementById('survey-modal-title');
 
     let searchTimer = null;
+    let surveyEditMode = false;  // tracks create vs edit mode for the survey modal
 
     function init() {
         const token = localStorage.getItem('caltrc_token');
@@ -64,6 +68,7 @@
         setupDateNav();
         setupSurveyForm();
         setupModalGuard();
+        setupEditProfile();
 
         loadSurveyAndMaybePrompt();
         loadGoals();
@@ -276,6 +281,7 @@
             <th>Protein</th>
             <th>Carbs</th>
             <th>Fat</th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
@@ -289,6 +295,14 @@
           <td>${e.protein}g</td>
           <td>${e.carbs}g</td>
           <td>${e.fat}g</td>
+          <td>
+            <button class="btn-delete-entry" data-entry-id="${esc(e.id)}" aria-label="Delete ${esc(e.name)}" title="Delete entry">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="3 6 5 6 21 6"></polyline>
+                <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"></path>
+              </svg>
+            </button>
+          </td>
         </tr>
       `;
         }
@@ -300,12 +314,22 @@
           <td>${totals.protein}g</td>
           <td>${totals.carbs}g</td>
           <td>${totals.fat}g</td>
+          <td></td>
         </tr>
         </tbody>
       </table>
     `;
 
         logContent.innerHTML = html;
+
+        // Attach delete handlers
+        logContent.querySelectorAll('.btn-delete-entry').forEach((btn) => {
+            btn.addEventListener('click', () => {
+                const entryId = btn.dataset.entryId;
+                const entryName = btn.closest('tr').querySelector('td').textContent;
+                deleteEntry(entryId, entryName);
+            });
+        });
     }
 
     function setupSurveyForm() {
@@ -329,8 +353,9 @@
 
             try {
                 const token = localStorage.getItem('caltrc_token');
+                const method = surveyEditMode ? 'PUT' : 'POST';
                 const res = await fetch('/api/survey', {
-                    method: 'POST',
+                    method,
                     headers: {
                         'Content-Type': 'application/json',
                         Authorization: `Bearer ${token}`,
@@ -345,8 +370,9 @@
                 }
 
                 hideSurveyModal();
+                surveyEditMode = false;
                 await loadGoals();
-                showToast('Profile saved! Your goals are ready.', 'success');
+                showToast(method === 'PUT' ? 'Profile updated!' : 'Profile saved! Your goals are ready.', 'success');
             } catch {
                 surveyStatus.textContent = 'Network error — please try again';
             } finally {
@@ -368,12 +394,14 @@
 
             // No survey yet — show the modal (covers new users AND existing users who skipped)
             if (res.status === 404) {
+                surveyEditMode = false;
                 showSurveyModal();
                 return;
             }
 
             // Any other non-OK response (server error etc.) — show modal so user isn't stuck
             if (!res.ok) {
+                surveyEditMode = false;
                 showSurveyModal();
                 return;
             }
@@ -389,8 +417,12 @@
             document.getElementById('survey-activity').value = byId.activityLevel || 'moderate';
 
             hideSurveyModal();
+
+            // Show the edit profile button since survey exists
+            if (editProfileBtn) editProfileBtn.style.display = '';
         } catch {
             // Network failure — show the modal so user can still complete their profile
+            surveyEditMode = false;
             showSurveyModal();
         }
     }
@@ -407,30 +439,54 @@
         surveyModal.setAttribute('aria-hidden', 'true');
     }
 
-    // Prevent the modal from being dismissed by clicking the backdrop or pressing Escape.
-    // The survey is required — users must complete it to get personalized goals.
+    // Prevent the modal from being dismissed by clicking the backdrop or pressing Escape
+    // when in create mode. In edit mode, allow dismissal.
     function setupModalGuard() {
         if (!surveyModal) return;
 
-        // Block backdrop clicks from closing
+        // Block backdrop clicks from closing in create mode
         surveyModal.addEventListener('click', (e) => {
             if (e.target === surveyModal) {
-                // Shake the modal to hint it must be completed
-                const modal = surveyModal.querySelector('.modal');
-                if (modal) {
-                    modal.classList.add('modal-shake');
-                    setTimeout(() => modal.classList.remove('modal-shake'), 400);
+                if (surveyEditMode) {
+                    // In edit mode, allow closing
+                    hideSurveyModal();
+                    surveyEditMode = false;
+                } else {
+                    // Shake the modal to hint it must be completed
+                    const modal = surveyModal.querySelector('.modal');
+                    if (modal) {
+                        modal.classList.add('modal-shake');
+                        setTimeout(() => modal.classList.remove('modal-shake'), 400);
+                    }
                 }
             }
         });
 
-        // Block Escape key
+        // Block Escape key in create mode only
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape' && !surveyModal.classList.contains('hidden')) {
-                e.preventDefault();
-                e.stopImmediatePropagation();
+                if (surveyEditMode) {
+                    hideSurveyModal();
+                    surveyEditMode = false;
+                } else {
+                    e.preventDefault();
+                    e.stopImmediatePropagation();
+                }
             }
         }, true);
+    }
+
+    function setupEditProfile() {
+        if (!editProfileBtn) return;
+        editProfileBtn.addEventListener('click', () => {
+            surveyEditMode = true;
+            if (surveyModalTitle) surveyModalTitle.textContent = 'Edit your health profile';
+            if (surveyHelp) surveyHelp.textContent = 'Update your info below to recalculate your daily targets.';
+            if (surveySubmitBtn) {
+                surveySubmitBtn.querySelector('.btn-text').textContent = 'Save changes';
+            }
+            showSurveyModal();
+        });
     }
 
     async function loadGoals() {
@@ -490,6 +546,29 @@
 
     function escapeAttr(str) {
         return str.replace(/'/g, '&#39;').replace(/"/g, '&quot;');
+    }
+
+    async function deleteEntry(entryId, entryName) {
+        if (!confirm(`Delete "${entryName}"?`)) return;
+
+        try {
+            const token = localStorage.getItem('caltrc_token');
+            const res = await fetch(`/api/log/${encodeURIComponent(entryId)}`, {
+                method: 'DELETE',
+                headers: { Authorization: `Bearer ${token}` },
+            });
+
+            if (!res.ok) {
+                const err = await res.json();
+                throw new Error(err.error || 'Failed to delete');
+            }
+
+            showToast('Entry deleted', 'success');
+            await loadLog(logDate.value);
+            await loadGoals();
+        } catch (err) {
+            showToast(err.message, 'error');
+        }
     }
 
     document.addEventListener('DOMContentLoaded', init);

--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,9 @@
         <div id="goal-content">
           <div class="log-empty">Loading goals...</div>
         </div>
+        <button class="btn btn-ghost btn-edit-profile" id="edit-profile-btn" style="display:none; margin-top: var(--sp-3);">
+          ✏️ Edit health profile
+        </button>
       </div>
     </section>
 
@@ -111,7 +114,7 @@
   <div class="modal-backdrop hidden" id="survey-modal-backdrop" aria-hidden="true">
     <div class="modal" role="dialog" aria-modal="true" aria-labelledby="survey-modal-title">
       <h2 id="survey-modal-title" class="section-title">Complete your health profile</h2>
-      <p class="survey-help">This one-time survey helps us calculate your personalized daily calorie and macro targets.</p>
+      <p class="survey-help" id="survey-help">This one-time survey helps us calculate your personalized daily calorie and macro targets.</p>
       <form id="survey-form">
         <div class="form-row">
           <div class="form-group">

--- a/public/styles.css
+++ b/public/styles.css
@@ -494,6 +494,39 @@ input::placeholder {
   background: var(--color-danger);
 }
 
+/* --- Delete Entry Button --- */
+.btn-delete-entry {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: all var(--duration-fast) var(--ease);
+}
+
+.btn-delete-entry:hover {
+  color: var(--color-danger);
+  background: #fef2f2;
+  border-color: var(--color-danger);
+  transform: scale(1.1);
+}
+
+.btn-delete-entry:active {
+  transform: scale(0.95);
+}
+
+/* --- Edit Profile Button --- */
+.btn-edit-profile {
+  font-size: var(--text-xs);
+  padding: var(--sp-1) var(--sp-3);
+}
+
 /* --- Responsive --- */
 @media (max-width: 600px) {
 

--- a/src/server.js
+++ b/src/server.js
@@ -220,6 +220,43 @@ app.post('/api/survey', requireAuth, async (req, res) => {
 });
 
 /**
+ * PUT /api/survey
+ * Update an existing survey.
+ * Body: { answers: [{ questionId, value }] }
+ */
+app.put('/api/survey', requireAuth, async (req, res) => {
+    if (!pool) {
+        return res.status(500).json({ error: 'Database is not configured. Set DATABASE_URL on Vercel.' });
+    }
+
+    const { answers } = req.body;
+
+    try {
+        // Check if a survey exists first
+        const existing = await getSurvey(req.user.id, pool);
+        if (!existing) {
+            return res.status(404).json({ error: 'No survey to update. Submit one first.' });
+        }
+
+        const surveyResult = await submitSurvey(req.user.id, answers, pool);
+        if (!surveyResult.success) {
+            return res.status(400).json({ errors: surveyResult.errors });
+        }
+
+        const goals = computeGoals(surveyResult.data);
+        await upsertGoalForToday(req.user.id, goals);
+
+        res.status(200).json({
+            survey: surveyResult.data,
+            goals,
+        });
+    } catch (err) {
+        console.error('Survey update error:', err);
+        res.status(500).json({ error: 'Failed to update survey' });
+    }
+});
+
+/**
  * GET /api/survey
  * Returns the authenticated user's survey if it exists.
  */
@@ -367,6 +404,29 @@ app.get('/api/log', requireAuth, (req, res) => {
         .catch((err) => {
             console.error('Load error:', err);
             res.status(500).json({ error: 'Failed to load entries' });
+        });
+});
+
+/**
+ * DELETE /api/log/:id
+ * Remove a food entry by ID for the authenticated user.
+ */
+app.delete('/api/log/:id', requireAuth, (req, res) => {
+    const entryId = req.params.id;
+
+    pool.query(
+        'DELETE FROM food_entries WHERE id = $1 AND user_id = $2 RETURNING id',
+        [entryId, req.user.id]
+    )
+        .then((result) => {
+            if (result.rows.length === 0) {
+                return res.status(404).json({ error: 'Entry not found' });
+            }
+            res.status(200).json({ deleted: true, id: entryId });
+        })
+        .catch((err) => {
+            console.error('Delete error:', err);
+            res.status(500).json({ error: 'Failed to delete entry' });
         });
 });
 


### PR DESCRIPTION
- Add PUT /api/survey endpoint for updating existing survey responses
- Add DELETE /api/log/:id endpoint for removing food entries
- Add 'Edit health profile' button on main page to reopen survey modal
- Add trash icon delete button on each food log row with confirm dialog
- Modal is dismissable in edit mode but stays mandatory for first-time survey
- Goals auto-refresh after survey edits and food deletions